### PR TITLE
Support for sharing image to Twitter added.

### DIFF
--- a/bufferJ/src/main/java/com/bufferj/client/util/CreateUpdates.java
+++ b/bufferJ/src/main/java/com/bufferj/client/util/CreateUpdates.java
@@ -22,7 +22,8 @@ public class CreateUpdates {
     private String mediaThumbnail;
     private Boolean attachment;
     private Long scheduledAt;
-
+    private String mediaPhoto;
+    
     public CreateUpdates() {
         this.profiles = new ArrayList<>();
     }
@@ -130,4 +131,11 @@ public class CreateUpdates {
     public void setScheduledAt(Long scheduledAt) {
         this.scheduledAt = scheduledAt;
     }
+	public String getMediaPhoto() {
+		return mediaPhoto;
+	}
+
+	public void setMediaPhoto(String mediaPhoto) {
+		this.mediaPhoto = mediaPhoto;
+	}
 }

--- a/bufferJ/src/main/java/com/bufferj/client/util/CreateUpdates.java
+++ b/bufferJ/src/main/java/com/bufferj/client/util/CreateUpdates.java
@@ -138,4 +138,5 @@ public class CreateUpdates {
 	public void setMediaPhoto(String mediaPhoto) {
 		this.mediaPhoto = mediaPhoto;
 	}
+    
 }

--- a/bufferJ/src/main/java/com/bufferj/client/util/EditUpdate.java
+++ b/bufferJ/src/main/java/com/bufferj/client/util/EditUpdate.java
@@ -18,7 +18,8 @@ public class EditUpdate {
     private String mediaPicture;
     private String mediaThumbnail;
     private Long scheduledAt;
-
+    private String mediaPhoto;
+    
     public String getText() {
         return text;
     }
@@ -74,4 +75,11 @@ public class EditUpdate {
     public void setScheduledAt(Long scheduledAt) {
         this.scheduledAt = scheduledAt;
     }
+    public String getMediaPhoto() {
+		return mediaPhoto;
+	}
+
+	public void setMediaPhoto(String mediaPhoto) {
+		this.mediaPhoto = mediaPhoto;
+	}
 }

--- a/bufferJ/src/main/java/com/bufferj/util/HttpUtil.java
+++ b/bufferJ/src/main/java/com/bufferj/util/HttpUtil.java
@@ -89,6 +89,9 @@ public class HttpUtil {
             formData.add(new BasicNameValuePair("scheduled_at", updates.getScheduledAt().toString()));
         }
 
+        if (updates.getMediaPhoto() != null) {
+            formData.add(new BasicNameValuePair("media[photo]", updates.getMediaPhoto().toString()));
+        }
         return formData;
     }
 
@@ -122,7 +125,9 @@ public class HttpUtil {
         if (update.getScheduledAt() != null) {
             formData.add(new BasicNameValuePair("scheduled_at", update.getScheduledAt().toString()));
         }
-
+        if (update.getMediaPhoto() != null) {
+            formData.add(new BasicNameValuePair("media[photo]", updates.getMediaPhoto().toString()));
+        }
         return formData;
     }
 }


### PR DESCRIPTION
To share an image to Twitter, the url of the image has to be provided with the _**photo**_ parameter of media, that is, media[photo]. BufferJ does not have wrappers for this. I have added support for this.

Explanation:
The 'media' parameter in Buffer API's _**POST /updates/create**_ & _**POST /updates/:id/update**_ endpoints can have the following parameters:
- link
- description
- title
- picture
- photo
- thumbnail.

As per Buffer's documentation, Twitter will ignore the link, picture, title, and description parameters. To share an image, media[photo] is required.